### PR TITLE
[CBP-40838] - Use latest gha image and set env JOB_CHECK_RUN_ID

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ inputs:
   component-id:
     description: >
       The ID of the component associated with the artifact. If not provided, the default is the component ID where the GHA workflow is located.
+  job-id:
+    description: 'The ID of the job to associate the build with.'
+    required: false
+    default: ${{ job.check_run_id }}
 
 outputs:
   cbp_artifact_id:
@@ -46,7 +50,7 @@ outputs:
 
 runs:
   using: "docker"
-  image: "docker://public.ecr.aws/l7o7z1g8/actions/gha-register-build-artifact:main-7b73e70a7a28ddd30cd7eaf62cc62f9bbae3f354"
+  image: "docker://public.ecr.aws/l7o7z1g8/actions/gha-register-build-artifact:main-6207469e6cbd3fa7e11460af85a6e299fb2da1ba"
   env:
     CLOUDBEES_API_URL: ${{ inputs.cloudbees-url }}
     ARTIFACT_NAME: ${{ inputs.name }}
@@ -59,3 +63,4 @@ runs:
     ARTIFACT_COMMIT: ${{ inputs.commit }}
     ARTIFACT_REF: ${{ inputs.ref }}
     ARTIFACT_COMPONENT_ID: ${{ inputs.component-id }}
+    JOB_CHECK_RUN_ID: ${{ inputs.job-id }}


### PR DESCRIPTION
Updated the action image that supports both id and name. Now, we are using check_run_id to track a job run